### PR TITLE
Add newline format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # stringtools
+
+This simple page provides tools for analyzing and formatting lists of values. Paste data into the input area and use **Analyze Data** to detect each value. Three formatting options are available:
+
+- **Format (Single Quotes)** – wraps each value in single quotes separated by commas.
+- **Format (Double Quotes)** – wraps each value in double quotes separated by commas.
+- **Format (New Lines)** – outputs values cleaned of quotes and commas, one per line.
+
+Use the language toggle to switch interface languages and the clear button to reset the form.

--- a/index.html
+++ b/index.html
@@ -91,10 +91,11 @@
                 <h1 id="input-title" class="text-2xl font-bold text-gray-800">Input Text</h1>
             </div>
             <textarea id="inputText" class="w-full flex-grow bg-gray-50 border border-gray-300 rounded-xl p-4 text-gray-700 focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 transition resize-none" rows="12" placeholder="Paste your data here... e.g.&#10;123, 456, 789&#10;23&#10;hello,world&#10;42"></textarea>
-            <div class="grid grid-cols-2 sm:grid-cols-2 gap-4 mt-6">
+            <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 mt-6">
                 <button id="analyzeBtn" class="btn btn-primary p-3 flex items-center justify-center"><i class="fas fa-search mr-2"></i>Analyze Data</button>
                 <button id="formatSingleBtn" class="btn btn-secondary p-3">Format (Single Quotes)</button>
                 <button id="formatDoubleBtn" class="btn btn-secondary p-3">Format (Double Quotes)</button>
+                <button id="formatNewlineBtn" class="btn btn-secondary p-3">Format (New Lines)</button>
                 <button id="clearBtn" class="btn btn-danger p-3 flex items-center justify-center"><i class="fas fa-trash-alt mr-2"></i>Clear</button>
             </div>
         </div>
@@ -141,6 +142,7 @@
         const analyzeBtn = document.getElementById('analyzeBtn');
         const formatSingleBtn = document.getElementById('formatSingleBtn');
         const formatDoubleBtn = document.getElementById('formatDoubleBtn');
+        const formatNewlineBtn = document.getElementById('formatNewlineBtn');
         const clearBtn = document.getElementById('clearBtn');
         const resultsMessage = document.getElementById('results-message');
         const detectionMessage = document.getElementById('detectionMessage');
@@ -160,11 +162,13 @@
                 analyzeData: 'Analyze Data',
                 formatSingle: 'Format (Single Quotes)',
                 formatDouble: 'Format (Double Quotes)',
+                formatNewline: 'Format (New Lines)',
                 clear: 'Clear',
                 results: 'Results',
                 formattedOutput: 'Formatted Output',
                 singleQuotes: 'Single Quotes',
                 doubleQuotes: 'Double Quotes',
+                newLines: 'New Lines',
                 copyHint: 'Click the formatted text or the icon to copy it.',
                 detection: 'Data dump detected! Found {count} values ready for processing.',
                 placeholder: 'Paste your data here... e.g.\n123, 456, 789\n23\nhello,world\n42'
@@ -174,11 +178,13 @@
                 analyzeData: 'Analizar Datos',
                 formatSingle: 'Formatear (Comillas simples)',
                 formatDouble: 'Formatear (Comillas dobles)',
+                formatNewline: 'Formatear (Nuevas líneas)',
                 clear: 'Limpiar',
                 results: 'Resultados',
                 formattedOutput: 'Salida Formateada',
                 singleQuotes: 'Comillas simples',
                 doubleQuotes: 'Comillas dobles',
+                newLines: 'Nuevas líneas',
                 copyHint: 'Haz clic en el texto formateado o el ícono para copiarlo.',
                 detection: '¡Volcado detectado! Se encontraron {count} valores listos para procesar.',
                 placeholder: 'Pega tus datos aquí... ej.\n123, 456, 789\n23\nhola,mundo\n42'
@@ -188,11 +194,13 @@
                 analyzeData: 'Analisar Dados',
                 formatSingle: 'Formatar (Aspas simples)',
                 formatDouble: 'Formatar (Aspas duplas)',
+                formatNewline: 'Formatar (Linhas)',
                 clear: 'Limpar',
                 results: 'Resultados',
                 formattedOutput: 'Saída Formatada',
                 singleQuotes: 'Aspas simples',
                 doubleQuotes: 'Aspas duplas',
+                newLines: 'Linhas',
                 copyHint: 'Clique no texto formatado ou no ícone para copiar.',
                 detection: 'Dump detectado! Encontrados {count} valores prontos para processar.',
                 placeholder: 'Cole seus dados aqui... ex.\n123, 456, 789\n23\nola,mundo\n42'
@@ -219,6 +227,7 @@
             analyzeBtn.innerHTML = '<i class="fas fa-search mr-2"></i>' + t('analyzeData');
             formatSingleBtn.textContent = t('formatSingle');
             formatDoubleBtn.textContent = t('formatDouble');
+            formatNewlineBtn.textContent = t('formatNewline');
             clearBtn.innerHTML = '<i class="fas fa-trash-alt mr-2"></i>' + t('clear');
             resultsTitle.textContent = t('results');
             formattedOutputTitle.textContent = t('formattedOutput') + ':';
@@ -236,6 +245,7 @@
         analyzeBtn.addEventListener('click', analyzeData);
         formatSingleBtn.addEventListener('click', () => formatData("'"));
         formatDoubleBtn.addEventListener('click', () => formatData('"'));
+        formatNewlineBtn.addEventListener('click', formatNewline);
         clearBtn.addEventListener('click', clearAll);
         copyBtn.addEventListener('click', copyToClipboard);
         formattedOutput.addEventListener('click', copyToClipboard);
@@ -252,7 +262,18 @@
             }
 
             const lines = text.split('\n').filter(line => line.trim() !== '');
-            const values = lines.flatMap(line => line.split(',').map(item => item.trim()).filter(item => item !== ''));
+            const values = lines.flatMap(line =>
+                line.split(',')
+                    .map(item => item.trim())
+                    .filter(item => item !== '')
+                    .map(item => {
+                        if ((item.startsWith('"') && item.endsWith('"')) ||
+                            (item.startsWith("'") && item.endsWith("'"))) {
+                            return item.slice(1, -1).trim();
+                        }
+                        return item;
+                    })
+            );
             
             parsedData = values;
             updateResultsUI();
@@ -291,6 +312,18 @@
             
             formattedOutput.value = formattedString;
             formattedOutputTitle.textContent = `${t('formattedOutput')} (${quoteType === "'" ? t('singleQuotes') : t('doubleQuotes')}):`;
+            formattedOutputContainer.classList.remove('hidden');
+        }
+
+        function formatNewline() {
+            if (parsedData.length === 0) {
+                analyzeData();
+                if (parsedData.length === 0) return;
+            }
+
+            const formattedString = parsedData.join('\n');
+            formattedOutput.value = formattedString;
+            formattedOutputTitle.textContent = `${t('formattedOutput')} (${t('newLines')}):`;
             formattedOutputContainer.classList.remove('hidden');
         }
 


### PR DESCRIPTION
## Summary
- allow cleaning pasted data with commas and quotes
- support exporting newline-delimited values with a new button
- localize button text in English, Spanish and Portuguese
- document the new feature in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68486ac3e1748333a02b2db0c45fb927