### PR TITLE
Add greeting after copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,8 @@
                         <i class="far fa-copy fa-lg"></i>
                     </button>
                 </div> -->
-                 <p id="copy-hint" class="text-xs text-gray-500 mt-2 text-center">Click the formatted text or the icon to copy it.</p>
+                <p id="copy-hint" class="text-xs text-gray-500 mt-2 text-center">Click the formatted text or the icon to copy it.</p>
+                <p id="copy-greeting" class="text-xs text-green-600 mt-2 text-center hidden"></p>
             </div>
         </div>
     </main>
@@ -193,6 +194,7 @@
         const inputTitle = document.getElementById('input-title');
         const resultsTitle = document.getElementById('results-title');
         const copyHintEl = document.getElementById('copy-hint');
+        const copyGreetingEl = document.getElementById('copy-greeting');
 
         const translations = {
             en: {
@@ -211,6 +213,7 @@
                 newLines: 'New Lines',
                 comma: 'Comma',
                 copyHint: 'Click the formatted text or the icon to copy it.',
+                copyGreeting: 'Copied! Greetings!',
                 detection: 'Data dump detected! Found {count} values ready for processing.',
                 placeholder: 'Paste your data here... e.g.\n123, 456, 789\n23\nhello,world\n42'
             },
@@ -230,6 +233,7 @@
                 newLines: 'Nuevas líneas',
                 comma: 'Coma',
                 copyHint: 'Haz clic en el texto formateado o el ícono para copiarlo.',
+                copyGreeting: '¡Copiado! ¡Saludos!',
                 detection: '¡Volcado detectado! Se encontraron {count} valores listos para procesar.',
                 placeholder: 'Pega tus datos aquí... ej.\n123, 456, 789\n23\nhola,mundo\n42'
             },
@@ -249,6 +253,7 @@
                 newLines: 'Linhas',
                 comma: 'Vírgula',
                 copyHint: 'Clique no texto formatado ou no ícone para copiar.',
+                copyGreeting: 'Copiado! Saudações!',
                 detection: 'Dump detectado! Encontrados {count} valores prontos para processar.',
                 placeholder: 'Cole seus dados aqui... ex.\n123, 456, 789\n23\nola,mundo\n42'
             }
@@ -282,6 +287,7 @@
             resultsTitle.textContent = t('results');
             formattedOutputTitle.textContent = t('formattedOutput') + ':';
             copyHintEl.textContent = t('copyHint');
+            copyGreetingEl.textContent = t('copyGreeting');
             inputText.placeholder = t('placeholder');
         }
 
@@ -293,6 +299,7 @@
         let parsedData = [];
         let currentSeparator = ',';
         let currentQuote = '';
+        let greetingTimeout;
 
         analyzeBtn.addEventListener('click', analyzeData);
         separatorCommaBtn.addEventListener('click', () => setSeparator(','));
@@ -406,6 +413,8 @@
             formattedOutput.value = '';
             formattedOutputContainer.classList.add('hidden');
             resultsMessage.classList.add('hidden');
+            copyGreetingEl.classList.add('hidden');
+            if (greetingTimeout) clearTimeout(greetingTimeout);
         }
 
         function copyToClipboard() {
@@ -418,6 +427,11 @@
             try {
                 document.execCommand('copy');
                 copyBtn.innerHTML = '<i class="fas fa-check text-green-600 fa-lg"></i>';
+                copyGreetingEl.classList.remove('hidden');
+                if (greetingTimeout) clearTimeout(greetingTimeout);
+                greetingTimeout = setTimeout(() => {
+                    copyGreetingEl.classList.add('hidden');
+                }, 2000);
                 setTimeout(() => {
                    copyBtn.innerHTML = '<i class="far fa-copy fa-lg"></i>';
                 }, 1500);

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
                 newLines: 'New Lines',
                 comma: 'Comma',
                 copyHint: 'Click the formatted text or the icon to copy it.',
-                copyGreeting: 'Copied! Greetings!',
+                copyGreeting: 'Copied to clipboard!',
                 detection: 'Data dump detected! Found {count} values ready for processing.',
                 placeholder: 'Paste your data here... e.g.\n123, 456, 789\n23\nhello,world\n42'
             },
@@ -234,7 +234,7 @@
                 newLines: 'Nuevas líneas',
                 comma: 'Coma',
                 copyHint: 'Haz clic en el texto formateado o el ícono para copiarlo.',
-                copyGreeting: '¡Copiado! ¡Saludos!',
+                copyGreeting: 'Copiado al portapapeles!',
                 detection: '¡Volcado detectado! Se encontraron {count} valores listos para procesar.',
                 placeholder: 'Pega tus datos aquí... ej.\n123, 456, 789\n23\nhola,mundo\n42'
             },
@@ -254,7 +254,7 @@
                 newLines: 'Linhas',
                 comma: 'Vírgula',
                 copyHint: 'Clique no texto formatado ou no ícone para copiar.',
-                copyGreeting: 'Copiado! Saudações!',
+                copyGreeting: 'Copiado!',
                 detection: 'Dump detectado! Encontrados {count} valores prontos para processar.',
                 placeholder: 'Cole seus dados aqui... ex.\n123, 456, 789\n23\nola,mundo\n42'
             }
@@ -429,9 +429,19 @@
                 document.execCommand('copy');
                 copyBtn.innerHTML = '<i class="fas fa-check text-green-600 fa-lg"></i>';
                 copyGreetingEl.classList.remove('hidden');
+                copyGreetingEl.style.opacity = '0';
+                copyGreetingEl.style.transition = 'opacity 0.4s';
+                // Fade in
+                setTimeout(() => {
+                    copyGreetingEl.style.opacity = '1';
+                }, 10);
                 if (greetingTimeout) clearTimeout(greetingTimeout);
                 greetingTimeout = setTimeout(() => {
-                    copyGreetingEl.classList.add('hidden');
+                    // Fade out
+                    copyGreetingEl.style.opacity = '0';
+                    setTimeout(() => {
+                        copyGreetingEl.classList.add('hidden');
+                    }, 400);
                 }, 1000);
                 setTimeout(() => {
                    copyBtn.innerHTML = '<i class="far fa-copy fa-lg"></i>';

--- a/index.html
+++ b/index.html
@@ -168,10 +168,11 @@
                     </button>
                 </div> -->
                 <p id="copy-hint" class="text-xs text-gray-500 mt-2 text-center">Click the formatted text or the icon to copy it.</p>
-                <p id="copy-greeting" class="text-xs text-green-600 mt-2 text-center hidden"></p>
             </div>
         </div>
     </main>
+
+    <div id="copy-greeting" class="hidden fixed top-4 right-4 bg-green-500 text-white text-sm px-4 py-2 rounded-lg shadow pointer-events-none"></div>
 
     <script>
         const inputText = document.getElementById('inputText');
@@ -431,7 +432,7 @@
                 if (greetingTimeout) clearTimeout(greetingTimeout);
                 greetingTimeout = setTimeout(() => {
                     copyGreetingEl.classList.add('hidden');
-                }, 2000);
+                }, 1000);
                 setTimeout(() => {
                    copyBtn.innerHTML = '<i class="far fa-copy fa-lg"></i>';
                 }, 1500);


### PR DESCRIPTION
## Summary
- show copy greeting message
- track copy greeting translations for English, Spanish, and Portuguese
- reset and hide greeting on clear

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685b0890e88083339dd79f31e76d9bc5