### PR TITLE
Add local translation tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,27 @@
         <button id="langToggle" class="absolute bottom-4 right-4 w-10 h-10 rounded-md bg-gray-200 flex items-center justify-center"></button>
     </header>
 
-    <main class="grid grid-cols-1 lg:grid-cols-2 gap-8 w-full max-w-6xl">
+    <main class="grid grid-cols-1 lg:grid-cols-3 gap-8 w-full max-w-6xl">
+        <div class="card p-8 flex flex-col">
+            <div class="flex items-center mb-6">
+                <div class="bg-blue-100 text-blue-600 p-2 rounded-lg mr-4">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m6 8h6m-6 4h6m-8 4h8" /></svg>
+                </div>
+                <h1 id="translate-title" class="text-2xl font-bold text-gray-800">Translate</h1>
+            </div>
+            <textarea id="translateInput" maxlength="100" class="w-full bg-gray-50 border border-gray-300 rounded-xl p-4 text-gray-700 focus:ring-2 focus:ring-indigo-400 focus:border-indigo-400 transition resize-y" rows="3" placeholder="Escribe texto en español..."></textarea>
+            <button id="translateBtn" class="btn btn-primary p-3 mt-4 flex items-center justify-center"><span id="translateBtnText">Translate Locally</span></button>
+            <div id="translation-output-container" class="mt-6 hidden">
+                <div class="relative">
+                    <h3 class="text-lg font-semibold text-gray-700 mb-2" id="translationOutputTitle">Translation:</h3>
+                    <button id="copyTranslationBtn" class="absolute top-1 right-3 text-gray-400 hover:text-black transition" title="Copy to clipboard">
+                        <i class="far fa-copy fa-lg"></i>
+                    </button>
+                </div>
+                <textarea id="translationOutput" readonly class="w-full bg-gray-900 text-green-400 font-mono text-sm border border-gray-700 rounded-xl p-4 pr-12 focus:outline-none resize-y" rows="3"></textarea>
+                <p id="translation-copy-hint" class="text-xs text-gray-500 mt-2 text-center">Click the translated text or the icon to copy it.</p>
+            </div>
+        </div>
         <div class="card p-8 flex flex-col">
             <div class="flex items-center mb-6">
                  <div class="bg-indigo-100 text-indigo-600 p-2 rounded-lg mr-4">
@@ -198,6 +218,15 @@
         const resultsTitle = document.getElementById('results-title');
         const copyHintEl = document.getElementById('copy-hint');
         const copyGreetingEl = document.getElementById('copy-greeting');
+        const translateInput = document.getElementById('translateInput');
+        const translateBtn = document.getElementById('translateBtn');
+        const translateTitle = document.getElementById('translate-title');
+        const translateBtnText = document.getElementById('translateBtnText');
+        const translationOutputContainer = document.getElementById('translation-output-container');
+        const translationOutputTitle = document.getElementById('translationOutputTitle');
+        const translationOutput = document.getElementById('translationOutput');
+        const copyTranslationBtn = document.getElementById('copyTranslationBtn');
+        const translationCopyHint = document.getElementById('translation-copy-hint');
 
         const translations = {
             en: {
@@ -218,7 +247,12 @@
                 copyHint: 'Click the formatted text or the icon to copy it.',
                 copyGreeting: 'Copied to clipboard!',
                 detection: 'Data dump detected! Found {count} values ready for processing.',
-                placeholder: 'Paste your data here... e.g.\n123, 456, 789\n23\nhello,world\n42'
+                placeholder: 'Paste your data here... e.g.\n123, 456, 789\n23\nhello,world\n42',
+                translateTitle: 'Translate',
+                translateLocally: 'Translate Locally',
+                translationOutput: 'Translation',
+                translationCopyHint: 'Click the translated text or the icon to copy it.',
+                translationPlaceholder: 'Type Spanish text here...'
             },
             es: {
                 inputText: 'Texto de Entrada',
@@ -238,7 +272,12 @@
                 copyHint: 'Haz clic en el texto formateado o el ícono para copiarlo.',
                 copyGreeting: 'Copiado al portapapeles!',
                 detection: '¡Volcado detectado! Se encontraron {count} valores listos para procesar.',
-                placeholder: 'Pega tus datos aquí... ej.\n123, 456, 789\n23\nhola,mundo\n42'
+                placeholder: 'Pega tus datos aquí... ej.\n123, 456, 789\n23\nhola,mundo\n42',
+                translateTitle: 'Traducir',
+                translateLocally: 'Traducir localmente',
+                translationOutput: 'Traducción',
+                translationCopyHint: 'Haz clic en el texto traducido o el ícono para copiarlo.',
+                translationPlaceholder: 'Escribe texto en español...'
             },
             pt: {
                 inputText: 'Texto de Entrada',
@@ -258,7 +297,12 @@
                 copyHint: 'Clique no texto formatado ou no ícone para copiar.',
                 copyGreeting: 'Copiado!',
                 detection: 'Dump detectado! Encontrados {count} valores prontos para processar.',
-                placeholder: 'Cole seus dados aqui... ex.\n123, 456, 789\n23\nola,mundo\n42'
+                placeholder: 'Cole seus dados aqui... ex.\n123, 456, 789\n23\nola,mundo\n42',
+                translateTitle: 'Traduzir',
+                translateLocally: 'Traduzir localmente',
+                translationOutput: 'Tradução',
+                translationCopyHint: 'Clique no texto traduzido ou no ícone para copiar.',
+                translationPlaceholder: 'Digite o texto em espanhol...'
             }
         };
 
@@ -292,6 +336,11 @@
             copyHintEl.textContent = t('copyHint');
             copyGreetingEl.textContent = t('copyGreeting');
             inputText.placeholder = t('placeholder');
+            translateTitle.textContent = t('translateTitle');
+            translateBtnText.textContent = t('translateLocally');
+            translationOutputTitle.textContent = t('translationOutput') + ':';
+            translationCopyHint.textContent = t('translationCopyHint');
+            translateInput.placeholder = t('translationPlaceholder');
         }
 
         function toggleLanguage() {
@@ -314,6 +363,9 @@
         copyBtn.addEventListener('click', copyToClipboard);
         formattedOutput.addEventListener('click', copyToClipboard);
         langToggle.addEventListener('click', toggleLanguage);
+        translateBtn.addEventListener('click', handleTranslate);
+        copyTranslationBtn.addEventListener('click', copyTranslation);
+        translationOutput.addEventListener('click', copyTranslation);
 
         setLanguage(currentLang);
 
@@ -442,6 +494,61 @@
                 }, 1000);
                 setTimeout(() => {
                    copyBtn.innerHTML = '<i class="far fa-copy fa-lg"></i>';
+                }, 1500);
+            } catch (err) {
+                console.error('Failed to copy text: ', err);
+            }
+            document.body.removeChild(textArea);
+        }
+
+        async function translateText(text) {
+            if (window.chrome && chrome.ai && chrome.ai.translate) {
+                return await chrome.ai.translate({ text, from: 'es', to: 'en' });
+            }
+            // Fallback placeholder
+            return text;
+        }
+
+        function handleTranslate() {
+            const text = translateInput.value.trim();
+            if (!text) return;
+
+            const original = translateBtnText.innerHTML;
+            translateBtn.disabled = true;
+            translateBtnText.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>' + t('translateLocally');
+
+            translateText(text).then(result => {
+                translationOutput.value = result;
+                translationOutputContainer.classList.remove('hidden');
+            }).catch(err => {
+                console.error('Translation failed', err);
+            }).finally(() => {
+                translateBtn.disabled = false;
+                translateBtnText.innerHTML = original;
+            });
+        }
+
+        function copyTranslation() {
+            if (!translationOutput.value) return;
+
+            const textArea = document.createElement('textarea');
+            textArea.value = translationOutput.value;
+            document.body.appendChild(textArea);
+            textArea.select();
+            try {
+                document.execCommand('copy');
+                copyTranslationBtn.innerHTML = '<i class="fas fa-check text-green-600 fa-lg"></i>';
+                copyGreetingEl.classList.remove('hidden');
+                copyGreetingEl.style.opacity = '0';
+                copyGreetingEl.style.transition = 'opacity 0.4s';
+                setTimeout(() => { copyGreetingEl.style.opacity = '1'; }, 10);
+                if (greetingTimeout) clearTimeout(greetingTimeout);
+                greetingTimeout = setTimeout(() => {
+                    copyGreetingEl.style.opacity = '0';
+                    setTimeout(() => { copyGreetingEl.classList.add('hidden'); }, 400);
+                }, 1000);
+                setTimeout(() => {
+                    copyTranslationBtn.innerHTML = '<i class="far fa-copy fa-lg"></i>';
                 }, 1500);
             } catch (err) {
                 console.error('Failed to copy text: ', err);

--- a/index.html
+++ b/index.html
@@ -509,15 +509,27 @@
             return text;
         }
 
-        function handleTranslate() {
+        const translator=undefined
+        async function handleTranslate() {
             const text = translateInput.value.trim();
             if (!text) return;
+            
+            if (!'Translator' in self) {
+                // The Translator API is supported.
+                alert('Traduccion no soportada, actualice su Navegador')
+                return
+            }
+            translator=translator?translator: await Translator.create({
+                sourceLanguage: 'es',
+                targetLanguage: 'en',
+                });
+            
 
             const original = translateBtnText.innerHTML;
             translateBtn.disabled = true;
             translateBtnText.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>' + t('translateLocally');
 
-            translateText(text).then(result => {
+            await translator.translate(text).then(result => {
                 translationOutput.value = result;
                 translationOutputContainer.classList.remove('hidden');
             }).catch(err => {

--- a/index.html
+++ b/index.html
@@ -509,7 +509,7 @@
             return text;
         }
 
-        const translator=undefined
+        let translator
         async function handleTranslate() {
             const text = translateInput.value.trim();
             if (!text) return;

--- a/index.html
+++ b/index.html
@@ -511,6 +511,11 @@
 
         let translator
         async function handleTranslate() {
+            const original = translateBtnText.innerHTML;
+            translateBtn.disabled = true;
+            translateBtnText.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>' + t('translateLocally');
+
+            
             const text = translateInput.value.trim();
             if (!text) return;
             
@@ -525,10 +530,7 @@
                 });
             
 
-            const original = translateBtnText.innerHTML;
-            translateBtn.disabled = true;
-            translateBtnText.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>' + t('translateLocally');
-
+         
             await translator.translate(text).then(result => {
                 translationOutput.value = result;
                 translationOutputContainer.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- add third card layout for a local translation feature
- implement translation controls and output copy action
- update language dictionaries and UI bindings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877cccb5ad08333a2c1d6c4a19e7eae